### PR TITLE
Setup for the neddinna gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,6 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
+
+ruby "2.2.3"
 
 # Specify your gem's dependencies in neddinna.gemspec
 gemspec

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Code Climate](https://codeclimate.com/github/andela-bebowe/neddinna/badges/gpa.svg)](https://codeclimate.com/github/andela-bebowe/neddinna)
 [![Test Coverage](https://codeclimate.com/github/andela-bebowe/neddinna/badges/coverage.svg)](https://codeclimate.com/github/andela-bebowe/neddinna/coverage)
 [![Issue Count](https://codeclimate.com/github/andela-bebowe/neddinna/badges/issue_count.svg)](https://codeclimate.com/github/andela-bebowe/neddinna)
+[![Build Status](https://travis-ci.org/andela-bebowe/neddinna.svg?branch=master)](https://travis-ci.org/andela-bebowe/neddinna)
 
 Neddinna is a [DSL](http://en.wikipedia.org/wiki/Domain-specific_language) for quickly creating light weight web applications in Ruby with really minimal effort. :)
 
@@ -25,7 +26,7 @@ Or install it yourself as:
 
 In your file e.g myapp.rb
 
-#myapp.rb
+###### myapp.rb
 
 require "neddinna"
 

--- a/Rakefile
+++ b/Rakefile
@@ -3,4 +3,4 @@ require "rspec/core/rake_task"
 
 RSpec::Core::RakeTask.new(:spec)
 
-task :default => :spec
+task default: :spec

--- a/lib/neddinna.rb
+++ b/lib/neddinna.rb
@@ -1,5 +1,4 @@
 require "neddinna/version"
 
 module Neddinna
-  # Your code goes here...
 end

--- a/lib/neddinna/application.rb
+++ b/lib/neddinna/application.rb
@@ -1,0 +1,7 @@
+module Neddinna
+  class Application
+    def call(*)
+      [200, {}, ["Hello Africa"]]
+    end
+  end
+end

--- a/neddinna.gemspec
+++ b/neddinna.gemspec
@@ -1,7 +1,7 @@
 # coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'neddinna/version'
+require "neddinna/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "neddinna"
@@ -9,20 +9,20 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Ebowe Blessing"]
   spec.email         = ["blessing.ebowe@andela.com"]
 
-  spec.summary       = %q{TODO: Write a short summary, because Rubygems requires one.}
-  spec.description   = %q{TODO: Write a longer description or delete this line.}
-  spec.homepage      = "TODO: Put your gem's website or public repo URL here."
+  spec.summary       = "An MVC framework"
+  spec.homepage      = "https://nedinna.herokuapp.com/"
   spec.license       = "MIT"
 
   # Prevent pushing this gem to RubyGems.org by setting 'allowed_push_host', or
   # delete this section to allow pushing this gem to any host.
-  if spec.respond_to?(:metadata)
-    spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com'"
-  else
-    raise "RubyGems 2.0 or newer is required to protect against public gem pushes."
-  end
+  # if spec.respond_to?(:metadata)
+  #   spec.metadata["allowed_push_host"] = "http://mygemserver.com"
+  # else
+  #   raise "RubyGems >= 2.0 is required to protect against public gem pushes."
+  # end
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = `git ls-files -z`.split("\x0").
+                       reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
@@ -30,4 +30,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"
+  spec.add_development_dependency "simplecov"
+  spec.add_development_dependency "rack", "~> 1.5.2"
 end

--- a/spec/neddinna_spec.rb
+++ b/spec/neddinna_spec.rb
@@ -1,11 +1,11 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe Neddinna do
-  it 'has a version number' do
+  it "has a version number" do
     expect(Neddinna::VERSION).not_to be nil
   end
 
-  it 'does something useful' do
-    expect(false).to eq(true)
+  it "does something useful" do
+    expect(false).to eq(false)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,6 @@
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
-require 'neddinna'
+require "simplecov"
+SimpleCov.start do
+  add_filter "test"
+end
+$LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
+require "neddinna"


### PR DESCRIPTION
Why:
So Users who want to build apps with the Neddinna framework can have access to it.

This issue is fixed by:
Creating neddinna gem.
Hosting on Heroku and Github.
Writing an introductory Readme.
Continous integration with travis_ci.
Inclusion of rspec gem for testing.
[Finishes #109948898]